### PR TITLE
Added methods to grant and revoke consent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -171,6 +171,30 @@ export default {
     }
   },
 
+  grantConsent() {
+    if (!verifyInit()) {
+      return;
+    }
+
+    fbq('consent', 'grant');
+
+    if (debug) {
+      log(`called fbq('consent', 'grant');`);
+    }
+  },
+
+  revokeConsent() {
+    if (!verifyInit()) {
+      return;
+    }
+
+    fbq('consent', 'revoke');
+
+    if (debug) {
+      log(`called fbq('consent', 'revoke');`);
+    }
+  },
+
   fbq(...args) {
     if (!verifyInit()) {
       return;


### PR DESCRIPTION
You can grant and revoke consent by calling fbq like this:

fbq('consent', 'grant');

or

fbq('consent', 'revoke');

This is usefull when you want the user to give permission to use tracking, wich is required by the GDPR: https://developers.facebook.com/docs/facebook-pixel/implementation/gdpr/

The documentation is not right, you have to call the function after the initialize.

I found that its easier to have the methods directly available than to look into the source code and to understand that you can call the fbq method and pass string arguments