### PR TITLE
export revokeConsent and grantConsent TS types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -184,3 +184,5 @@ export function trackSingleCustom(
   data?: Data | any,
 ): void;
 export function fbq(...args: Array<unknown>): void;
+export function revokeConsent(): void;
+export function grantConsent(): void;


### PR DESCRIPTION
This PR exports TS types for `ReactPixel.revokeConsent()` and `ReactPixel.grantConsent()`.