### PR TITLE
fix readme installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 ## Install
 
 ```bash
-npm install --save @zsajjad/react-facebook-pixel
+npm install --save react-facebook-pixel
 
 ```
 
 or
 
 ```bash
-yarn add @zsajjad/react-facebook-pixel
+yarn add react-facebook-pixel
 
 ```
 


### PR DESCRIPTION
Fixes the `readme` installation method. Using both `yarn add @zsajjad/react-facebook-pixel` and `npm install --save @zsajjad /react-facebook-pixel` would end up throwing an error saying the package wasn't found. This happens because the package is available as `react-facebook-pixel` on npm.