### PR TITLE
Update AdvancedMatching type to include external_id

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,6 +14,7 @@ export interface AdvancedMatching {
   ph: string;
   st: string;
   zp: string;
+  external_id: string;
 }
 
 export interface Data {}


### PR DESCRIPTION
Super minimal change but `external_id` is a valid option on the [facebook pixel docs](https://developers.facebook.com/docs/facebook-pixel/advanced/advanced-matching) and it's missing from the `AdvancedMatching` type. Instead of overriding the type on my end, I figured I'd add it incase anyone else needs it!