### PR TITLE
Fix node build where window reference throws

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
  */
 
 //
-let initialized = !!window.fbq;
+let initialized = (typeof window !== 'undefined') && !!window.fbq;
 let debug = false;
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@
  */
 
 //
-let initialized = (typeof window !== 'undefined') && !!window.fbq;
+let initialized = false;
 let debug = false;
 
 /**
@@ -55,6 +55,7 @@ const defaultOptions = {
 //
 export default {
   init(pixelId, advancedMatching = {}, options = defaultOptions) {
+    initialized = (typeof window !== 'undefined') && !!window.fbq;
     /* eslint-disable */
     !(function(f, b, e, v, n, t, s) {
       if (f.fbq) return;


### PR DESCRIPTION
When I was building Gatsby project with node I run into missing window exception. This PR fixes it by adding type check and moves it into init functiton.