### PR TITLE
Fixed Interface AdvancedMatching typing

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -4,16 +4,17 @@ export interface Options {
 }
 
 export interface AdvancedMatching {
-  ct: string;
-  country: string;
-  db: string;
-  em: string;
-  fn: string;
-  ge: string;
-  ln: string;
-  ph: string;
-  st: string;
-  zp: string;
+  ct?: string;
+  country?: string;
+  db?: string;
+  em?: string;
+  fn?: string;
+  ge?: string;
+  ln?: string;
+  ph?: string;
+  st?: string;
+  zp?: string;
+  external_id?: string;
 }
 
 export interface Data {}


### PR DESCRIPTION
This PR is to set all of the properties to AdvancedMatching to optional, as well as adding the external_id to the list since that can be used.

This PR is an enhancement of https://github.com/zsajjad/react-facebook-pixel/pull/59 - that one just wants to add external_id - whereas this one does that + makes them all optional.